### PR TITLE
Take into account global offsets of corners #3

### DIFF
--- a/src/Leaflet.ControlledBounds.js
+++ b/src/Leaflet.ControlledBounds.js
@@ -21,13 +21,24 @@
 			// This assumes that all corner controls are placed vertically to one another.
 			// Oh $deity, what a mess of spaghetti code and casuistics.
 			var size = this.getSize();
-			var candidates = {
+			var corners = (this._controlCorners.topright.offsetLeft && this._controlCorners.bottomleft.offsetTop && this._controlCorners.bottomright.offsetLeft && this._controlCorners.bottomright.offsetTop) ? {
 				topleft:     [L.point(this._controlCorners.topleft.offsetLeft, this._controlCorners.topleft.offsetTop)],
 				topright:    [L.point(this._controlCorners.topright.offsetLeft + this._controlCorners.topright.offsetWidth, this._controlCorners.topright.offsetTop)],
 				bottomleft:  [L.point(this._controlCorners.bottomleft.offsetLeft, this._controlCorners.bottomleft.offsetTop + this._controlCorners.bottomleft.offsetHeight)],
 				bottomright: [L.point(this._controlCorners.bottomright.offsetLeft + this._controlCorners.bottomright.offsetWidth, this._controlCorners.bottomright.offsetTop + this._controlCorners.bottomright.offsetHeight)]
+			} : {
+				topleft:     [L.point(0, 0)],
+				topright:    [L.point(size.x, 0)],
+				bottomleft:  [L.point(0, size.y)],
+				bottomright: [L.point(size.x, size.y)]
 			};
-			var previousBottom = this._controlCorners.topleft.offsetTop;
+			var candidates = {
+				topleft:     [L.point(corners.topleft[0].x, corners.topleft[0].y)],
+				topright:    [L.point(corners.topright[0].x, corners.topright[0].y)],
+				bottomleft:  [L.point(corners.bottomleft[0].x, corners.bottomleft[0].y)],
+				bottomright: [L.point(corners.bottomright[0].x, corners.bottomright[0].y)]
+			};
+			var previousBottom = corners.topleft[0].y;
 			for (var i=0; i<this._controlCorners.topleft.children.length; i++) {
 				var child = this._controlCorners.topleft.children[i];
 				if (child.offsetTop + child.offsetLeft + child.offsetWidth + child.offsetHeight > 0) {
@@ -43,13 +54,13 @@
 						}
 					}
 					candidates.topleft.push(L.point(childRight, previousBottom));
-					candidates.topleft.push(L.point(this._controlCorners.topleft.offsetLeft, childBottom));
+					candidates.topleft.push(L.point(corners.topleft[0].x, childBottom));
 
 					previousBottom = childBottom;
 				}
 			}
 
-			previousBottom = this._controlCorners.topright.offsetTop;
+			previousBottom = corners.topright[0].y;
 			for (var i=0; i<this._controlCorners.topright.children.length; i++) {
 				var child = this._controlCorners.topright.children[i];
 				if (child.offsetTop + child.offsetLeft + child.offsetWidth + child.offsetHeight > 0) {
@@ -65,13 +76,13 @@
 						}
 					}
 					candidates.topright.push(L.point(childLeft, previousBottom));
-					candidates.topright.push(L.point(this._controlCorners.topright.offsetLeft + this._controlCorners.topright.offsetWidth, childBottom));
+					candidates.topright.push(L.point(corners.topright[0].x, childBottom));
 
 					previousBottom = childBottom;
 				}
 			}
 
-			var previousTop = this._controlCorners.bottomleft.offsetTop;
+			var previousTop = corners.bottomleft[0].y;
 			for (var i=this._controlCorners.bottomleft.children.length - 1; i>=0; i--) {
 				var child = this._controlCorners.bottomleft.children[i];
 				if (child.offsetTop + child.offsetLeft + child.offsetWidth + child.offsetHeight > 0) {
@@ -87,13 +98,13 @@
 						}
 					}
 					candidates.bottomleft.push(L.point(childRight, previousTop));
-					candidates.bottomleft.push(L.point(this._controlCorners.bottomleft.offsetLeft, childTop));
+					candidates.bottomleft.push(L.point(corners.bottomleft[0].x, childTop));
 
 					previousTop = childTop;
 				}
 			}
 
-			previousTop = this._controlCorners.bottomright.offsetTop;
+			previousTop = corners.bottomright[0].y;
 			for (var i=this._controlCorners.bottomright.children.length - 1; i>=0; i--) {
 				var child = this._controlCorners.bottomright.children[i];
 				if (child.offsetTop + child.offsetLeft + child.offsetWidth + child.offsetHeight > 0) {
@@ -109,7 +120,7 @@
 						}
 					}
 					candidates.bottomright.push(L.point(childLeft, previousTop));
-					candidates.bottomright.push(L.point(this._controlCorners.bottomright.offsetLeft + this._controlCorners.bottomright.offsetWidth, childTop));
+					candidates.bottomright.push(L.point(corners.bottomright[0].x, childTop));
 
 					previousTop = childTop;
 				}

--- a/src/Leaflet.ControlledBounds.js
+++ b/src/Leaflet.ControlledBounds.js
@@ -22,17 +22,17 @@
 			// Oh $deity, what a mess of spaghetti code and casuistics.
 			var size = this.getSize();
 			var candidates = {
-				topleft:     [L.point(0, 0)],
-				topright:    [L.point(size.x, 0)],
-				bottomleft:  [L.point(0, size.y)],
-				bottomright: [L.point(size.x, size.y)]
+				topleft:     [L.point(this._controlCorners.topleft.offsetLeft, this._controlCorners.topleft.offsetTop)],
+				topright:    [L.point(this._controlCorners.topright.offsetLeft + this._controlCorners.topright.offsetWidth, this._controlCorners.topright.offsetTop)],
+				bottomleft:  [L.point(this._controlCorners.bottomleft.offsetLeft, this._controlCorners.bottomleft.offsetTop + this._controlCorners.bottomleft.offsetHeight)],
+				bottomright: [L.point(this._controlCorners.bottomright.offsetLeft + this._controlCorners.bottomright.offsetWidth, this._controlCorners.bottomright.offsetTop + this._controlCorners.bottomright.offsetHeight)]
 			};
-			var previousBottom = 0;
+			var previousBottom = this._controlCorners.topleft.offsetTop;
 			for (var i=0; i<this._controlCorners.topleft.children.length; i++) {
 				var child = this._controlCorners.topleft.children[i];
 				if (child.offsetTop + child.offsetLeft + child.offsetWidth + child.offsetHeight > 0) {
 					var childTop    = child.offsetTop;
-					var childLeft   = child.offsetLeft;
+					var childLeft   = child.offsetLeft + this._controlCorners.topleft.offsetLeft;
 					var childBottom = childTop + child.offsetHeight;
 					var childRight  = childLeft + child.offsetWidth;
 
@@ -43,13 +43,13 @@
 						}
 					}
 					candidates.topleft.push(L.point(childRight, previousBottom));
-					candidates.topleft.push(L.point(0, childBottom));
+					candidates.topleft.push(L.point(this._controlCorners.topleft.offsetLeft, childBottom));
 
 					previousBottom = childBottom;
 				}
 			}
 
-			previousBottom = 0;
+			previousBottom = this._controlCorners.topright.offsetTop;
 			for (var i=0; i<this._controlCorners.topright.children.length; i++) {
 				var child = this._controlCorners.topright.children[i];
 				if (child.offsetTop + child.offsetLeft + child.offsetWidth + child.offsetHeight > 0) {
@@ -65,18 +65,18 @@
 						}
 					}
 					candidates.topright.push(L.point(childLeft, previousBottom));
-					candidates.topright.push(L.point(size.x, childBottom));
+					candidates.topright.push(L.point(this._controlCorners.topright.offsetLeft + this._controlCorners.topright.offsetWidth, childBottom));
 
 					previousBottom = childBottom;
 				}
 			}
 
-			var previousTop = size.y;
+			var previousTop = this._controlCorners.bottomleft.offsetTop;
 			for (var i=this._controlCorners.bottomleft.children.length - 1; i>=0; i--) {
 				var child = this._controlCorners.bottomleft.children[i];
 				if (child.offsetTop + child.offsetLeft + child.offsetWidth + child.offsetHeight > 0) {
 					var childTop    = child.offsetTop + this._controlCorners.bottomleft.offsetTop;
-					var childLeft   = child.offsetLeft;
+					var childLeft   = child.offsetLeft + this._controlCorners.bottomleft.offsetLeft;
 					var childBottom = childTop + child.offsetHeight;
 					var childRight  = childLeft + child.offsetWidth;
 
@@ -87,13 +87,13 @@
 						}
 					}
 					candidates.bottomleft.push(L.point(childRight, previousTop));
-					candidates.bottomleft.push(L.point(0, childTop));
+					candidates.bottomleft.push(L.point(this._controlCorners.bottomleft.offsetLeft, childTop));
 
 					previousTop = childTop;
 				}
 			}
 
-			previousTop = size.y;
+			previousTop = this._controlCorners.bottomright.offsetTop;
 			for (var i=this._controlCorners.bottomright.children.length - 1; i>=0; i--) {
 				var child = this._controlCorners.bottomright.children[i];
 				if (child.offsetTop + child.offsetLeft + child.offsetWidth + child.offsetHeight > 0) {
@@ -109,7 +109,7 @@
 						}
 					}
 					candidates.bottomright.push(L.point(childLeft, previousTop));
-					candidates.bottomright.push(L.point(size.x, childTop));
+					candidates.bottomright.push(L.point(this._controlCorners.bottomright.offsetLeft + this._controlCorners.bottomright.offsetWidth, childTop));
 
 					previousTop = childTop;
 				}
@@ -121,7 +121,6 @@
 			candidates.bottomright = candidates.bottomright.filter(function(i){return !!i;});
 
 // 			console.log(candidates);
-
 
 			// Try out all combinations of the candidate corners, stick with the one that gives
 			//   out the biggest area.


### PR DESCRIPTION
As I've asked in #3 issue, it would be better if ControlledBounds takes into account other controls added for instance by other leaflet plugin (I've checked with plugin [leaflet-sidebar](https://github.com/Turbo87/leaflet-sidebar).
With my modifications, plugin doesn't use anymore size of the map but offsets of corners. Now Leaflet.ControlledBounds is compatible with leaflet-sidebar and I think all controls added by others.

Fabien
